### PR TITLE
Avoid react warnings by adding key to Links.

### DIFF
--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -26,10 +26,8 @@ class App extends Component {
       '/parent?foo=bar',
       '/parent/child?bar=baz',
       '/parent/child/123?baz=foo'
-    ].map(l =>
-      <p>
-        <Link to={l}>{l}</Link>
-      </p>
+    ].map((l, i) =>
+      <Link key={i} to={l}>{l}</Link>
     );
 
     return (

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -27,7 +27,9 @@ class App extends Component {
       '/parent/child?bar=baz',
       '/parent/child/123?baz=foo'
     ].map((l, i) =>
-      <Link key={i} to={l}>{l}</Link>
+      <p key={i}>
+        <Link to={l}>{l}</Link>
+      </p>
     );
 
     return (


### PR DESCRIPTION
Made a small change to the examples by adding a key to each link element, as not having a key while mapping over an array otherwise throws a warning.
