### PR TITLE
Up version of history

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^1.3.1",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.1",
-    "history": "^1.9.0",
+    "history": "^1.11.1",
     "jsdom": "^5.6.0",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",


### PR DESCRIPTION
There is a problem when try to ```npm shrinkwrap``` cause redux-router download history module with 1.9.1 version instead of last 1.11.1