### PR TITLE
Persist hash fragments in request URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^1.3.1",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.1",
-    "history": "^1.9.0",
+    "history": "^1.12.2",
     "jsdom": "^5.6.0",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",

--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -79,7 +79,7 @@ const routes = (
 describe('<ReduxRouter>', () => {
   jsdom();
 
-  function renderApp() {
+  function renderApp(route = '/parent/child/123?key=value') {
     const reducer = combineReducers({
       router: routerStateReducer
     });
@@ -89,7 +89,7 @@ describe('<ReduxRouter>', () => {
       history
     })(createStore)(reducer);
 
-    history.pushState(null, '/parent/child/123?key=value');
+    history.pushState(null, route);
 
     return renderIntoDocument(
       <Provider store={store}>
@@ -99,6 +99,13 @@ describe('<ReduxRouter>', () => {
       </Provider>
     );
   }
+
+  it('persists a hash fragment in the URL', () => {
+    const tree = renderApp('/parent/child/123#hash');
+    const child = findRenderedComponentWithType(tree, Child);
+    expect(child.props.location.pathname).to.equal('/parent/child/123');
+    expect(child.props.location.hash).to.equal('#hash');
+  });
 
   it('renders a React Router app using state from a Redux <Provider>', () => {
     const tree = renderApp();

--- a/src/client.js
+++ b/src/client.js
@@ -33,7 +33,8 @@ function historySynchronization(next) {
         nextRouterState &&
         !routerStateEquals(routerState, nextRouterState)
       ) {
-        const { state, pathname, query } = nextRouterState.location;
+        let { state, pathname, query } = nextRouterState.location;
+        if(nextRouterState.location.hasOwnProperty('hash')) pathname = `${pathname}${nextRouterState.location.hash}`
         history.replaceState(state, pathname, query);
       }
 

--- a/src/routeReplacement.js
+++ b/src/routeReplacement.js
@@ -21,7 +21,8 @@ export default function routeReplacement(next) {
 
       const routerState = routerStateSelector(store.getState());
       if (routerState) {
-        const { state, pathname, query } = routerState.location;
+        let { state, pathname, query } = routerState.location;
+        if(routerState.location.hasOwnProperty('hash')) pathname = `${pathname}${routerState.location.hash}`
         store.history.replaceState(state, pathname, query);
       }
 

--- a/src/routerStateEquals.js
+++ b/src/routerStateEquals.js
@@ -12,6 +12,7 @@ export default function routerStateEquals(a, b) {
 
   return (
     a.location.pathname === b.location.pathname &&
+    a.location.hash == b.location.hash &&
     a.location.search === b.location.search &&
     deepEqual(a.location.state, b.location.state)
   );


### PR DESCRIPTION
So, I've noticed that there are problems with redux-router persisting the hash fragment in a URI. This seems to be related to some other issues in the react-router and history repos. I'm not 100% sure that this pull request is the right solution, although it does solve the immediate issue I'm experiencing in which reduxRouter strips hashes out of the location. Hopefully it's enough to give you a head start on a fix, if it's not the right solution.

In theory, the problem should be easy to reproduce. Append #something to any URL handled by redux-router, and you should see it get removed in the browser URL bar.

Note that I'm updating the history module to pull in a bugfix to related issue rackt/history#51 in that repo, which was fixed this morning.

For back story on this, see rackt/history#51, rackt/react-router#2176 and rackt/react-router#2177