### PR TITLE
Failing test: routerDidChange called twice on mount

### DIFF
--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -79,17 +79,15 @@ const routes = (
 describe('<ReduxRouter>', () => {
   jsdom();
 
-  function renderApp() {
-    const reducer = combineReducers({
-      router: routerStateReducer
-    });
+  function renderApp(router = routerStateReducer) {
+    const reducer = combineReducers({router});
 
     const history = createHistory();
+    history.pushState(null, '/parent/child/123?key=value');
+
     const store = reduxReactRouter({
       history
     })(createStore)(reducer);
-
-    history.pushState(null, '/parent/child/123?key=value');
 
     return renderIntoDocument(
       <Provider store={store}>
@@ -121,6 +119,19 @@ describe('<ReduxRouter>', () => {
 
     Simulate.click(link);
     expect(child.props.location.pathname).to.equal('/parent/child/321');
+  });
+
+  it('should call REPLACE_ROUTES and ROUTER_DID_CHANGE once during initialization', () => {
+    const actions = [];
+
+    renderApp((state, action) => {
+      if (action && action.type.indexOf('@@reduxReactRouter') === 0) {
+        actions.push(action.type);
+      }
+      return routerStateReducer(state, action);
+    });
+
+    expect(actions).to.eql(['@@reduxReactRouter/routerDidChange', '@@reduxReactRouter/replaceRoutes']);
   });
 
   describe('server-side rendering', () => {


### PR DESCRIPTION
So I'm not sure what the correct behavior here should be, but (as seen in the attached test) it looks like the `ROUTER_DID_CHANGE` action runs twice when initializing.

I believe this line here: https://github.com/rackt/redux-router/blob/7eaf206f86fdf73eab620dff94aa2f66984dd5da/src/routerStateReducer.js#L19 is meant for the initialization, but it never gets called, so the `DOES_NEED_REFRESH` is attached to the existing state when mounting the router.

I wasn't sure the cleanest fix, was thinking about maybe an `INIT_ROUTES` rather than running both the constructor and componentWillUpdate through `refreshRoutes` but wanted to see whether this should be considered a bug.