### PR TITLE
Examples webpack config should alias redux-router

### DIFF
--- a/examples/webpack.config.base.js
+++ b/examples/webpack.config.base.js
@@ -16,7 +16,7 @@ export default {
   },
   resolve: {
     alias: {
-      'redux-react-router': PROJECT_SRC
+      'redux-router': PROJECT_SRC
     },
     extensions: ['', '.js']
   }


### PR DESCRIPTION
The code imports `redux-router` now instead of `redux-react-router`. Alias the newer module name.