### PR TITLE
Fix dependencies of history

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint": "^1.3.1",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.1",
-    "history": "^1.9.0",
     "jsdom": "^5.6.0",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
@@ -49,6 +48,7 @@
     "webpack": "^1.12.1"
   },
   "dependencies": {
-    "deep-equal": "^1.0.1"
+    "deep-equal": "^1.0.1",
+    "history": "^1.9.0"
   }
 }


### PR DESCRIPTION
I tried `npm shrinkwrap` on an app that has `redux-router` as dependencies.
But an error occurs because `history` exists in `devDependencies` instead of `dependencies`.

```
➜  npm i -S redux-router@1.0.0-beta4
redux-router@1.0.0-beta4 node_modules/redux-router
└── deep-equal@1.0.1
➜  npm shrinkwrap
npm ERR! Darwin 15.0.0
npm ERR! argv "/Users/koba04/.anyenv/envs/ndenv/versions/v4.2.2/bin/node" "/Users/koba04/.anyenv/envs/ndenv/versions/v4.2.2/bin/npm" "shrinkwrap"
npm ERR! node v4.2.2
npm ERR! npm  v2.14.7

npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! extraneous: history@1.9.0 /Users/koba04/Desktop/test/node_modules/redux-router/node_modules/history
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/koba04/Desktop/test/npm-debug.log
➜  ls node_modules
redux-router
```

This PR is to fix that issue.
Thanks.