### PR TITLE
Need to check undefined location prop for async as well as null

### DIFF
--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -86,7 +86,7 @@ class ReduxRouterContext extends Component {
   render() {
     const {location} = this.props;
 
-    if (location === null)
+    if (location === null || location === undefined)
       return null; // Async matching
 
     const RoutingContext = this.props.RoutingContext || DefaultRoutingContext;


### PR DESCRIPTION
Fully finishing the work done in #202 

`react-router` is able to just check null because it checks against its initial state, but the prop unpacking using spread syntax will make the location set to `undefined` in `ReduxRouterContext`

Noticed that @yesmeck pointed this out