### PR TITLE
Moved `initRoutes` dispatch to `componentWillMount`

### DIFF
--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -33,7 +33,10 @@ class ReduxRouter extends Component {
 
   constructor(props, context) {
     super(props, context);
-    context.store.dispatch(initRoutes(getRoutesFromProps(props)));
+  }
+
+  componentWillMount() {
+    this.context.store.dispatch(initRoutes(getRoutesFromProps(this.props)));
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Thanks a ton for putting together `redux-router` -- it's super awesome and has helped me a ton over the past few months. :+1:

In something I'm working on right now, the `ReduxRouter` component is conditionally rendered / isn't at the root of my application, which was leading to a stream of the following errors : 
```
Warning: setState(...): Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
```

Moving the dispatch to `componentWillMount` resolves this issue.