### PR TITLE
Pass correct key for stringifyQuery in createAppHistory

### DIFF
--- a/src/reduxReactRouter.js
+++ b/src/reduxReactRouter.js
@@ -25,7 +25,7 @@ export default function reduxReactRouter({
 
     const history = createAppHistory({
       parseQueryString,
-      stringifyQueryString: stringifyQuery,
+      stringifyQuery,
     });
 
     const transitionManager = createTransitionManager(


### PR DESCRIPTION
Previously we were using `stringifyQueryString`, which was ignored by `createAppHistory`. So now we use `stringifyQuery` instead.

See https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#custom-query-string-parsing