### PR TITLE
Fix casing of pathname parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Provided that `order.id` is set and equals `123` it will change browser address 
 A bit more advanced example:
 ```js
 dispatch(push({
-  pathName: '/orders',
+  pathname: '/orders',
   query: { filter: 'shipping' }
 }));
 ```


### PR DESCRIPTION
Took me some time to understand why it didn't work :) 
So I fixed this little mistake.