### PR TITLE
Implement UMD build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 *.log
 lib
 /server.js
+dist

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "Redux bindings for React Router — keep your router state inside your Redux Store.",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel src --out-dir lib && cp lib/serverModule.js server.js",
-    "clean": "rimraf lib && rimraf server.js",
+    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
+    "build:commonjs": "babel src --out-dir lib && cp lib/serverModule.js server.js",
+    "build:umd": "NODE_ENV=development browserify -s ReduxRouter --detect-globals lib/index.js -o dist/redux-router.js",
+    "build:umd:min": "NODE_ENV=production browserify -s ReduxRouter --detect-globals lib/index.js | uglifyjs -c warnings=false -m > dist/redux-router.min.js",
+    "clean": "rimraf lib && rimraf dist && rimraf server.js",
     "lint": "eslint src",
     "test": "mocha --compilers js:babel/register --recursive --require src/__tests__/init.js src/**/*-test.js",
     "test-watch": "mocha --compilers js:babel/register --recursive --require src/__tests__/init.js -w src/**/*-test.js",
-    "prepublish": "npm run clean && npm run build"
+    "prepublish": "npm run clean && mkdir dist && npm run build"
   },
   "repository": {
     "type": "git",
@@ -23,11 +26,20 @@
   ],
   "author": "Andrew Clark <acdlite@me.com>",
   "license": "MIT",
+  "files": [
+	  "dist",
+	  "lib",
+	  "src",
+	  "LICENSE",
+	  "*.md"
+
+  ],
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "5.6.15",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^5.3.2",
+    "browserify": "^13.0.1",
     "chai": "^3.0.0",
     "eslint": "^1.3.1",
     "eslint-config-airbnb": "0.0.8",
@@ -47,6 +59,7 @@
     "redux-devtools": "^2.1.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.15.4",
+    "uglify-js": "^2.6.2",
     "webpack": "^1.12.1"
   },
   "dependencies": {


### PR DESCRIPTION
This allows redux-router to be run in the browser and hosted on CDNs. Redux-router is available in the browser as window.ReduxRouter.