### PR TITLE
Fixes test warning

### DIFF
--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -64,7 +64,7 @@ class Child extends Component {
 }
 
 function redirectOnEnter(pathname) {
-  return (routerState, replace) => replace(null, pathname);
+  return (routerState, replace) => replace({ pathname });
 }
 
 const routes = (


### PR DESCRIPTION
Fixes "Warning: [react-router] `replaceState(state, pathname, query) is deprecated; use`replace(location)` with a location descriptor instead. http://tiny.cc/router-isActivedeprecated"
