### PR TITLE
Add failing test for redirect with query string in onEnter

### DIFF
--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -293,6 +293,36 @@ describe('reduxRouter()', () => {
         .to.equal('/login');
     });
 
+    it('can perform redirects with query string', () => {
+      const reducer = combineReducers({
+        router: routerStateReducer
+      });
+
+      const history = createHistory();
+
+      const requireAuth = (nextState, redirect) => {
+        redirect({ pathname: '/login', query: { key: 'value' } });
+      };
+
+      const store = reduxReactRouter({
+        history,
+        routes: (
+          <Route path="/">
+            <Route path="parent">
+              <Route path="child/:id" onEnter={requireAuth}/>
+            </Route>
+            <Route path="login" />
+          </Route>
+        )
+      })(createStore)(reducer);
+
+      store.dispatch(push({ pathname: '/parent/child/123' }));
+      expect(store.getState().router.location.pathname)
+        .to.equal('/login');
+      expect(store.getState().router.location.query.key)
+        .to.equal('value');
+    });
+
     describe('isActive', () => {
       it('creates a selector for whether a pathname/query pair is active', () => {
         const reducer = combineReducers({


### PR DESCRIPTION
When using the `query` parameter in the `redirect` call in the `onEnter` hook, the query is added twice. This can be seen in the failing test output:

```
AssertionError: expected [ 'value', 'value' ] to equal 'value'
```

Use case for the `query` parameter: redirect the user to the requested path after logging in.
