### PR TITLE
Fixed react-router@3 "Cannot read property 'location' of undefined"

### DIFF
--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -34,7 +34,7 @@ class ReduxRouter extends Component {
 
   constructor(props, context) {
     super(props, context);
-    this.router = createRouterObject(context.store.history, context.store.transitionManager);
+    this.router = createRouterObject(context.store.history, context.store.transitionManager, {});
   }
 
   componentWillMount() {


### PR DESCRIPTION
https://github.com/ReactTraining/react-router/commit/a76efddfa20945807a422ac88860b7108f0cf4d5
@acdlite without this fix this library won't work with `react-router@3` which is now the default version