### PR TITLE
[#289] Use independent 'prop-types' package.

### DIFF
--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { createStore, compose, combineReducers } from 'redux';
 

--- a/examples/server-rendering/components.js
+++ b/examples/server-rendering/components.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {Link} from 'react-router';
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "node-libs-browser": "^0.5.2",
+    "prop-types": "^15.6.0",
     "react": "^0.14.1",
     "react-addons-test-utils": "^0.14.1",
     "react-dom": "^0.14.1",

--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { RouterContext as DefaultRoutingContext } from 'react-router';
 import { createRouterObject } from 'react-router/lib/RouterUtils';

--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -7,7 +7,8 @@ import {
 
 import * as server from '../server';
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { renderToString } from 'react-dom/server';
 import {
   renderIntoDocument,


### PR DESCRIPTION
Addressing issue [#289 React.PropTypes is deprecated in React@15.5](https://github.com/acdlite/redux-router/issues/289).